### PR TITLE
Add dropdown for Spring Cloud Services archive PDFs

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -116,6 +116,18 @@
             </div>
           </div>
         <% end %>
+        <% if page_classes.match(/^spring-cloud-services /) %>
+          <div class="header-dropdown">
+            <a class="header-dropdown-link" >
+              v1.0.0
+            </a>
+            <div class="header-dropdown-content">
+              <ul>
+              <li><a href="/archives/p-spring-cloud-services/spring-cloud-services-docs-0.1.1.BETA.pdf">v0.1.1.BETA</a></li>
+              </ul>
+            </div>
+          </div>
+        <% end %>
         <div class="header-links js-bar-links">
           <div class="btn-menu" data-behavior="MenuMobile"></div>
           <%= vars.product_link %>


### PR DESCRIPTION
We're archiving Spring Cloud Services’s 0.1.1 BETA docs and didn't have a version selector for that yet—this adds it.
