### PR TITLE
Increase page load speed

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -6,6 +6,7 @@
   <!-- Always force latest IE rendering engine or request Chrome Frame -->
   <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
 
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300italic,400italic,400,600' rel='stylesheet' type='text/css'>
   <!-- Use title if it's in the page YAML frontmatter -->
   <title>
     <% if data.page.title %>
@@ -65,31 +66,11 @@
 
 <div class="viewport">
   <div class='wrap'>
-    <script src="//use.typekit.net/clb0qji.js" type="text/javascript"></script>
-    <script type="text/javascript">
-      try {
-        Typekit.load();
-      } catch (e) {
-      }
-    </script>
     <script type="text/javascript">
       document.domain = "<%= vars.domain_name %>";
     </script>
 
-    <script type="text/javascript">
-      WebFontConfig = {
-        google: {families: ['Source+Sans+Pro:300italic,400italic,300,400,600:latin']}
-      };
-      (function() {
-        var wf = document.createElement('script');
-        wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-            '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
-        wf.type = 'text/javascript';
-        wf.async = 'true';
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(wf, s);
-      })();
-    </script>
+
 
     <% if vars.use_global_header && current_page.data.owner != "Identity Service" && current_page.data.owner != "MySQL" && current_page.data.owner != "Pivotal HD" &&  current_page.data.owner != "Spring Cloud Services" %>
       <header class="global-header header header-layout">


### PR DESCRIPTION
As PCF service authors, we frequently refer to docs.pivotal.io to supplement our product. On a Pivotal internet connection, we measure a Load time of ~1000ms for a page and notice a flash of unstyled text (FOUT) on every page load. This commit makes three improvements:
1. **Remove unused Typekit ref**
   
   We observed that a Typekit script was pulling in "Proxima Nova" and "Freight Sans Pro" as additional fonts for the website. We looked through the codebase to see if these fonts were being used in the SCSS. Proxima Nova was not being used at all. Freight Sans Pro was only being used in the vendored dcaccordion plugin. Such minor usage warrants removing the Typekit reference, thereby saving 300 KB and ~100 ms.
2. **Move the Google Web Fonts reference above the main stylesheet
   declaration.**
   
   Acquiring the font before using it in the main stylesheet mitigates the risk of a flash of unstyled text.
3. **Use the HTML stylesheet link to obtain the Google Web Font**
   
   The JS Web Font Loader gives you more control over font loading than the Google Fonts API provides. The Web Font Loader also lets you use multiple web font providers. We do not appear to be taking advantage of this, so it will be advantageous to defer to the browser for load order.

Signed-off-by: Mike Kenyon mkenyon@pivotal.io @mkenyon
