### PR TITLE
Add clustering and partitions nav item to rabbitmq docs

### DIFF
--- a/source/subnavs/pivotal_rabbitmq_service_subnav.erb
+++ b/source/subnavs/pivotal_rabbitmq_service_subnav.erb
@@ -20,6 +20,9 @@
         <a href="/rabbitmq-cf/policies.html">Policies</a>
       </li>
       <li class="first expanded js-maintopic">
+        <a href="/rabbitmq-cf/partitions.html">Clustering and Network Partitions</a>
+      </li>
+      <li class="first expanded js-maintopic">
         <a href="/rabbitmq-cf/managing.html">Managing</a>
       </li>
       <li class="first expanded js-maintopic">


### PR DESCRIPTION
This adds the new partitions page into the rabbitmq service nav. Sibling to [this pull request](https://github.com/pivotal-cf/docs-rabbitmq-staging/pull/36)
