### PR TITLE
release ODB v0.6.0

### DIFF
--- a/source/layouts/_header.erb
+++ b/source/layouts/_header.erb
@@ -89,7 +89,8 @@
 
           <div class="header-dropdown-content">
             <ul>
-              <li><a href="/on-demand-service-broker">v0.5.0</a></li>
+              <li><a href="/on-demand-service-broker">v0.6.0</a></li>
+              <li><a href="/on-demand-service-broker-v0-5-0">v0.5.0</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
We have released a new version of ODB, and need our header to list all versions.

This depends on https://github.com/pivotal-cf/docs-book-pcfservices/pull/17

Cheers!

cc @avade 
