### PR TITLE
Allow books to override the header links

### DIFF
--- a/source/layouts/_header-links.erb
+++ b/source/layouts/_header-links.erb
@@ -1,0 +1,14 @@
+<div class='header-links'>
+    <div class="header-item">
+        <a href="https://tanzu.vmware.com/support">Support</a>
+    </div>
+    <div class="header-item">
+        <a href="https://network.pivotal.io">Downloads</a>
+    </div>
+    <div class='header-item' id='contact-header-item'>
+        <a href='https://tanzu.vmware.com/contact'>Contact Us</a>
+    </div>
+    <div class='header-item'>
+        <a href="https://login.run.pivotal.io">Sign In</a>
+    </div>
+</div>

--- a/source/layouts/_header.erb
+++ b/source/layouts/_header.erb
@@ -41,20 +41,7 @@
         <a href="/" class="global-header-title">
           <img class="pivotal-logo" src="https://d1fto35gcfffzn.cloudfront.net/images/docs/logo-tanzu-docs.svg">
         </a>
-        <div class='header-links'>
-           <div class="header-item">
-            <a href="https://tanzu.vmware.com/support">Support</a>
-          </div>
-          <div class="header-item">
-            <a href="https://network.pivotal.io">Downloads</a>
-          </div>
-          <div class='header-item' id='contact-header-item'>
-            <a href='https://tanzu.vmware.com/contact'>Contact Us</a>
-          </div>
-          <div class='header-item'>
-            <a href="https://login.run.pivotal.io">Sign In</a>
-          </div>
-        </div>
+        <%= partial 'layouts/header-links' %>
       </div>
     </div>
     <div id='info-search-bar'>


### PR DESCRIPTION
- This is useful for other docs sites deployed to an airgapped environment.

Authored-by: Patrick Oyarzun <poyarzun@pivotal.io>